### PR TITLE
EDX-4263 Update XRT client func

### DIFF
--- a/clients/interfaces/xrt.go
+++ b/clients/interfaces/xrt.go
@@ -21,7 +21,7 @@ type XrtClient interface {
 	AddDiscoveredDevice(ctx context.Context, device models.Device) errors.EdgeX
 	ScanDevice(ctx context.Context, device models.Device) errors.EdgeX
 
-	ReadDeviceResources(ctx context.Context, deviceName string, resourceNames []string) (map[string]xrtmodels.Reading, errors.EdgeX)
+	ReadDeviceResources(ctx context.Context, deviceName string, resourceNames []string) (xrtmodels.MultiResourcesResult, errors.EdgeX)
 	WriteDeviceResources(ctx context.Context, deviceName string, resourceValuePairs, options map[string]interface{}) errors.EdgeX
 
 	AllSchedules(ctx context.Context) ([]string, errors.EdgeX)

--- a/clients/xpert/xrtdevice.go
+++ b/clients/xpert/xrtdevice.go
@@ -107,15 +107,15 @@ func (c *xrtClient) ScanDevice(ctx context.Context, device models.Device) errors
 	return nil
 }
 
-func (c *xrtClient) ReadDeviceResources(ctx context.Context, deviceName string, resourceNames []string) (map[string]xrtmodels.Reading, errors.EdgeX) {
+func (c *xrtClient) ReadDeviceResources(ctx context.Context, deviceName string, resourceNames []string) (xrtmodels.MultiResourcesResult, errors.EdgeX) {
 	request := xrtmodels.NewDeviceResourceGetRequest(deviceName, clientName, resourceNames)
 	var response xrtmodels.MultiResourcesResponse
 
 	err := c.sendXrtRequest(ctx, request.RequestId, request, &response)
 	if err != nil {
-		return nil, errors.NewCommonEdgeX(errors.Kind(err), "failed to read device resources", err)
+		return xrtmodels.MultiResourcesResult{}, errors.NewCommonEdgeX(errors.Kind(err), "failed to read device resources", err)
 	}
-	return response.Result.Readings, nil
+	return response.Result, nil
 }
 
 func (c *xrtClient) WriteDeviceResources(ctx context.Context, deviceName string, resourceValuePairs, options map[string]interface{}) errors.EdgeX {


### PR DESCRIPTION
ReadDeviceResources client function should return MultiResourcesResult because it contains the deviceName, profileName, sourceName, and tags that are important to the client.