### PR TITLE
PS-881 Add MQTT connection resilience with auto-reconnect on publish failure

### DIFF
--- a/clients/central/xrt.go
+++ b/clients/central/xrt.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2023-2024 IOTech Ltd
+// Copyright (C) 2023-2026 IOTech Ltd
 
 package central
 
@@ -162,13 +162,17 @@ func (c *xrtClient) sendXrtRequestWithTimeout(ctx context.Context, requestTopic 
 
 	err = c.messageBus.PublishBinaryData(jsonData, requestTopic)
 	if err != nil {
+		c.requestMap.Delete(requestId)
 		return errors.NewCommonEdgeX(errors.Kind(err), "failed to send the XRT request", err)
 	}
 
+	c.lc.Debugf("Waiting for XRT response, requestId: %s", requestId)
 	cmdResponseBytes, err := utils.FetchXRTResponse(ctx, requestId, c.requestMap, responseTimeout)
 	if err != nil {
+		c.lc.Errorf("Failed to fetch XRT response for requestId %s: %s", requestId, err.Error())
 		return errors.NewCommonEdgeXWrapper(err)
 	}
+	c.lc.Debugf("Received XRT response for requestId: %s", requestId)
 
 	err = json.Unmarshal(cmdResponseBytes, response)
 	if err != nil {
@@ -200,6 +204,7 @@ func (c *xrtClient) sendXrtRequestWithSubTimeout(ctx context.Context, requestTop
 
 	err = c.messageBus.PublishBinaryData(jsonData, requestTopic)
 	if err != nil {
+		c.requestMap.Delete(requestId)
 		return errors.NewCommonEdgeX(errors.Kind(err), "failed to send the XRT request", err)
 	}
 

--- a/internal/pkg/mqtt/central.go
+++ b/internal/pkg/mqtt/central.go
@@ -20,7 +20,7 @@ func (mc *Client) PublishBinaryData(data []byte, topic string) error {
 
 	optionsReader := mc.mqttClient.OptionsReader()
 
-	return getTokenError(
+	err := getTokenError(
 		mc.mqttClient.Publish(
 			topic,
 			optionsReader.WillQos(),
@@ -29,6 +29,27 @@ func (mc *Client) PublishBinaryData(data []byte, topic string) error {
 		optionsReader.ConnectTimeout(),
 		PublishOperation,
 		"Unable to publish message")
+	if err == nil {
+		return nil
+	}
+
+	// If publish failed and connection is lost, attempt reconnect and retry once.
+	if !mc.IsConnected() {
+		if reconnErr := mc.Connect(); reconnErr != nil {
+			return NewOperationErr(PublishOperation, "connection lost and reconnect failed: "+reconnErr.Error())
+		}
+		return getTokenError(
+			mc.mqttClient.Publish(
+				topic,
+				optionsReader.WillQos(),
+				optionsReader.WillRetained(),
+				data),
+			optionsReader.ConnectTimeout(),
+			PublishOperation,
+			"Unable to publish message after reconnect")
+	}
+
+	return err
 }
 
 func (mc *Client) SubscribeBinaryData(topics []types.TopicChannel, messageErrors chan error) error {

--- a/internal/pkg/mqtt/client.go
+++ b/internal/pkg/mqtt/client.go
@@ -52,6 +52,8 @@ type Client struct {
 	unmarshaller          MessageUnmarshaller
 	existingSubscriptions map[string]existingSubscription
 	subscriptionMutex     *sync.Mutex
+	connectMutex          *sync.Mutex
+	subsReady             chan struct{} // closed by onConnectHandler when all subscriptions are re-established
 }
 
 type existingSubscription struct {
@@ -70,6 +72,7 @@ func NewMQTTClient(config types.MessageBusConfig) (*Client, error) {
 		unmarshaller:          json.Unmarshal,
 		existingSubscriptions: map[string]existingSubscription{},
 		subscriptionMutex:     new(sync.Mutex),
+		connectMutex:          new(sync.Mutex),
 	}
 
 	return client, nil
@@ -89,6 +92,7 @@ func NewMQTTClientWithCreator(
 		unmarshaller:          unmarshaller,
 		existingSubscriptions: make(map[string]existingSubscription),
 		subscriptionMutex:     new(sync.Mutex),
+		connectMutex:          new(sync.Mutex),
 	}
 
 	return client, nil
@@ -97,6 +101,9 @@ func NewMQTTClientWithCreator(
 // Connect establishes a connection to a MQTT server.
 // This must be called before any other functionality provided by the Client.
 func (mc *Client) Connect() error {
+	mc.connectMutex.Lock()
+	defer mc.connectMutex.Unlock()
+
 	if mc.mqttClient == nil {
 		// Move created MQTT Client here since we need to set the onConnectHandler which needs to have access to
 		// the Client's activeSubscriptions. This was not possible from the factory method.
@@ -108,18 +115,56 @@ func (mc *Client) Connect() error {
 	}
 
 	// Avoid reconnecting if already connected.
-	if mc.mqttClient.IsConnected() {
+	if mc.mqttClient.IsConnectionOpen() {
 		return nil
 	}
 
 	optionsReader := mc.mqttClient.OptionsReader()
 
-	return getTokenError(
+	connectTimeout := optionsReader.ConnectTimeout()
+
+	// Paho's Disconnect() is unreliable when the client is reconnecting. Instead, replace the
+	// paho client with a fresh instance. The old client is cleaned up in the background;
+	// the MQTT broker will terminate the old connection when it sees the same ClientID.
+	oldClient := mc.mqttClient
+	go oldClient.Disconnect(0)
+
+	newClient, err := mc.creator(mc.configuration, mc.onConnectHandler)
+	if err != nil {
+		return err
+	}
+	mc.mqttClient = newClient
+
+	// Prepare channel for onConnectHandler to signal when subscriptions are ready.
+	hasSubscriptions := len(mc.existingSubscriptions) > 0
+	if hasSubscriptions {
+		mc.subsReady = make(chan struct{})
+	}
+
+	connectErr := getTokenError(
 		mc.mqttClient.Connect(),
-		optionsReader.ConnectTimeout(),
+		connectTimeout,
 		ConnectOperation,
 		"Unable to connect")
+	if connectErr != nil {
+		return connectErr
+	}
+
+	// Wait for onConnectHandler to finish re-subscribing before returning.
+	// onConnectHandler runs in a separate goroutine (paho: go c.options.OnConnect(c)),
+	// so without this wait, callers may publish before subscriptions are re-established.
+	if hasSubscriptions {
+		select {
+		case <-mc.subsReady:
+			return nil
+		case <-time.After(connectTimeout):
+			return NewTimeoutError(ConnectOperation, "timed out waiting for subscriptions to be re-established")
+		}
+	}
+
+	return nil
 }
+
 
 func (mc *Client) onConnectHandler(_ pahoMqtt.Client) {
 	optionsReader := mc.mqttClient.OptionsReader()
@@ -139,6 +184,11 @@ func (mc *Client) onConnectHandler(_ pahoMqtt.Client) {
 		if err != nil {
 			subscription.errors <- err
 		}
+	}
+
+	// Signal that all subscriptions have been re-established.
+	if mc.subsReady != nil {
+		close(mc.subsReady)
 	}
 }
 
@@ -211,6 +261,14 @@ func (mc *Client) Unsubscribe(topics ...string) error {
 	}
 
 	return nil
+}
+
+// IsConnected returns true if the MQTT client has an active connection.
+func (mc *Client) IsConnected() bool {
+	if mc.mqttClient == nil {
+		return false
+	}
+	return mc.mqttClient.IsConnectionOpen()
 }
 
 // Disconnect closes the connection to the connected MQTT server.

--- a/internal/pkg/mqtt/client_test.go
+++ b/internal/pkg/mqtt/client_test.go
@@ -211,7 +211,7 @@ func (MockMQTTClient) IsConnected() bool {
 }
 
 func (MockMQTTClient) IsConnectionOpen() bool {
-	panic("function not expected to be invoked")
+	return false
 }
 
 func (MockMQTTClient) SubscribeMultiple(map[string]byte, pahoMqtt.MessageHandler) pahoMqtt.Token {

--- a/internal/pkg/nats/client.go
+++ b/internal/pkg/nats/client.go
@@ -216,6 +216,11 @@ func (c *Client) Unsubscribe(topics ...string) error {
 	return errs
 }
 
+// IsConnected returns true if the NATS connection exists.
+func (c *Client) IsConnected() bool {
+	return c.connection != nil
+}
+
 // Disconnect drains open subscriptions before closing
 func (c *Client) Disconnect() error {
 	if c.connection == nil {

--- a/internal/pkg/noopclient.go
+++ b/internal/pkg/noopclient.go
@@ -45,6 +45,10 @@ func (n NoopClient) Subscribe(topics []types.TopicChannel, messageErrors chan er
 	panic("implement me")
 }
 
+func (n NoopClient) IsConnected() bool {
+	panic("implement me")
+}
+
 func (n NoopClient) Disconnect() error {
 	panic("implement me")
 }

--- a/internal/pkg/redis/client.go
+++ b/internal/pkg/redis/client.go
@@ -1,7 +1,7 @@
 /********************************************************************************
  *  Copyright 2020 Dell Inc.
  *  Copyright (c) 2023 Intel Corporation
- *  Copyright (C) 2023 IOTech Ltd
+ *  Copyright (C) 2023-2026 IOTech Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -226,6 +226,11 @@ func (c Client) Unsubscribe(topics ...string) error {
 	}
 
 	return nil
+}
+
+// IsConnected returns true if the Redis client exists and is ready.
+func (c Client) IsConnected() bool {
+	return c.redisClient != nil
 }
 
 // Disconnect closes connections to the Redis server.

--- a/messaging/interface.go
+++ b/messaging/interface.go
@@ -1,5 +1,6 @@
 //
 // Copyright (c) 2023 Intel Corporation
+// Copyright (c) 2026 IOTech Ltd
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -49,6 +50,9 @@ type MessageClient interface {
 
 	// Unsubscribe to unsubscribe from the specified topics.
 	Unsubscribe(topics ...string) error
+
+	// IsConnected returns true if the client is currently connected to the message bus
+	IsConnected() bool
 
 	// Disconnect is to close all connections on the message bus
 	// and TopicChannel will also be closed

--- a/messaging/mocks/MessageClient.go
+++ b/messaging/mocks/MessageClient.go
@@ -29,6 +29,20 @@ func (_m *MessageClient) Connect() error {
 	return r0
 }
 
+// IsConnected provides a mock function with given fields:
+func (_m *MessageClient) IsConnected() bool {
+	ret := _m.Called()
+
+	var r0 bool
+	if rf, ok := ret.Get(0).(func() bool); ok {
+		r0 = rf()
+	} else {
+		r0 = ret.Get(0).(bool)
+	}
+
+	return r0
+}
+
 // Disconnect provides a mock function with given fields:
 func (_m *MessageClient) Disconnect() error {
 	ret := _m.Called()


### PR DESCRIPTION
- Add IsConnected() to MessageClient interface using paho's IsConnectionOpen() for accurate connection state detection
- PublishBinaryData auto-detects disconnection on publish failure, creates a fresh paho client to reconnect, and retries once
- Connect() uses connectMutex to prevent concurrent reconnections and waits for onConnectHandler to finish re-subscribing before returning, avoiding the race where publish succeeds but response subscription is not yet established
- Fix requestMap entry leak by calling requestMap.Delete(requestId) when publish fails, preventing orphaned entries that were previously never cleaned up